### PR TITLE
update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # Usage
 
+## Basic Example
 Add the following step to a GitHub workflow file:
 ```
-- uses: concord-consortium/s3-deploy-action@main
+- uses: concord-consortium/s3-deploy-action@v1
   with:
     bucket: models-resources
     prefix: name-of-project
     awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
     awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    topBranches: |
-      ["main"]
 ```
 You should replace `name-of-project` with the repository name.
 
@@ -20,11 +19,6 @@ S3. The location in S3 depends on if this is a branch or tag:
 - If it is a tag it will be:
 `models-resources/name-of-project/version/[tag-name]`
 
-This action currently assumes there will be an index.html and index-top.html file created
-in `dist` by the build. The index-top.html should reference its dependencies using a
-prefix of `branch/[branch-name]/` or `version/[tag-name]/`. This way the index-top.html
-can be copied up and will be able to find its resources.
-
 The max-age of the files in branches is configured to be 0. This way changes to branches
 are seen immediately. Branches should not be used in production with high numbers of users.
 
@@ -32,20 +26,48 @@ The max-age of the files in the version folder is set to be 1 year. Versions sho
 so they can be cached basically forever.  
 
 The index files have their max-age set to 0 even for versions. These files should be small
-so it isn't important if they are cached. Also when the index-top.html file is copied to
-the top level that change should apply immediately.
+so it isn't important if they are cached. This is also needed for the top branch feature
+described below.
 
-The list of branches in topBranches will have their `index-top.html` file copied and
+The build command can be overridden with the `build` option.
+
+The folder where the build command is run can be overridden with `workingDirectory`.
+
+The folder that is copied to S3 can be overridden with `folderToDeploy`. Its value is
+relative to the `workingDirectory`.
+
+## Top Branch Example
+This action also support a concept of top branches. A simple configuration of this is:
+
+```
+- uses: concord-consortium/s3-deploy-action@v1
+  with:
+    bucket: models-resources
+    prefix: name-of-project
+    awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    topBranches:
+      - main
+```
+
+If `topBranches` is specified, the action assumes there will be an an index-top.html file
+created in the `folderToDeploy`. The index-top.html should reference its dependencies
+using a prefix of `branch/[branch-name]/` or `version/[tag-name]/`. This way the
+index-top.html can be copied up two levels and still be able to find its resources.
+The build command is passed this prefix in an environment variable named `DEPLOY_PATH`.
+
+The list of branches in `topBranches` will have their `index-top.html` file copied and
 renamed with the branch name.
 So in this case, if the main branch is pushed,
 `models-resources/name-of-project/branch/main/index-top.html` will be copied
 to `models-resources/name-of-project/index-main.html`
 
+Because the index files have their max-age set to 0, when they are copied to the top level
+this change will appear immediately in browsers requesting the file even if they have
+requested it before. 
+
 You can see an example of this being used in this PR:
 https://github.com/concord-consortium/starter-projects/pull/37
-
-Note: we should release the action so the first line can refer to a version instead of
-`@main`.  Currently there are no releases.
 
 # Develop
 

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,14 @@ inputs:
     required: false
   folderToDeploy:
     description: the folder created by the build command that should be deployed.
-      It is relative to the workdingDirectory if that is set.
+      It is relative to the workingDirectory if that is set.
       Default is 'dist'
     required: false
 outputs:
   deployPath:
-    description: 'The location where the files will be stored'
+    description: An additional path added to the prefix.
+      If it is a tag build it will be '/version/{tag-name}'.
+      If it is a branch build it will be '/branch/{branch-name}'.
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
The simple case without top branches is hopefully more clear now.
And the top branches examples includes info about the DEPLOY_PATH that was
missing before.