### PR TITLE
Add option to allow empty prefixes

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -141,6 +141,23 @@ test('s3Update with matching top branch but no index-top.html calls correct sync
   ]);
 })
 
+test('s3Update with noPrefix option set calls correct sync and copy commands', async () => {
+  await s3Update({
+    deployPath: 'branch/test-branch',
+    branch: 'test-branch',
+    bucket: 'test-bucket',
+    prefix: 'fake-app',
+    noPrefix: true,
+    localFolder: 'test-dist-folders/basic'
+  });
+
+  const execMock = (exec.exec as any).mock;
+  expect(execMock.calls).toEqual([
+    ['aws s3 sync ./test-dist-folders/basic s3://test-bucket/branch/test-branch --delete --exclude "*index.html" --exclude "*index-top.html" --cache-control "max-age=0"'],
+    ['aws s3 cp ./test-dist-folders/basic s3://test-bucket/branch/test-branch --recursive --exclude "*" --include "*index.html" --include "*index-top.html" --cache-control "no-cache, max-age=0"']
+  ]);
+})
+
 // Test the action using the env / stdout protocol
 test('test runs', () => {
   process.env['GITHUB_REF'] = "refs/heads/test-branch";

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   prefix:
     description: S3 prefix to prepend to files uploaded to S3
     required: true
+  noPrefix:
+    description: If "true" the prefix is not used for the top level bucket
+    required: false
   topBranches:
     description: A JSON array of branch names (without PT number) for which the
       index-top.html file will be copied to the top. The file name will be

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ async function run(): Promise<void> {
 
     const bucket = core.getInput("bucket");
     const prefix = core.getInput("prefix");
+    const noPrefix = core.getInput("noPrefix") === "true"; // allows top level bucket deploys if true
     const topBranchesJSON = core.getInput("topBranches");
     const folderToDeploy = core.getInput("folderToDeploy");
     const localFolderParts = [];
@@ -34,7 +35,7 @@ async function run(): Promise<void> {
     }
     localFolderParts.push(folderToDeploy || "dist");
     const localFolder = localFolderParts.join("/");
-    if (bucket && prefix) {
+    if (bucket && (prefix || noPrefix)) {
       process.env.AWS_ACCESS_KEY_ID = core.getInput("awsAccessKeyId");
       process.env.AWS_SECRET_ACCESS_KEY = core.getInput("awsSecretAccessKey");
       process.env.AWS_DEFAULT_REGION = "us-east-1";
@@ -45,6 +46,7 @@ async function run(): Promise<void> {
         branch,
         bucket,
         prefix,
+        noPrefix,
         topBranchesJSON,
         localFolder });
     }

--- a/src/s3-update.ts
+++ b/src/s3-update.ts
@@ -8,7 +8,8 @@ export interface S3UpdateOptions {
   bucket: string,
   prefix: string,
   topBranchesJSON?: string,
-  localFolder: string
+  localFolder: string,
+  noPrefix?: boolean
 }
 
 const MAX_AGE_VERSION_SECS = 60*60*24*365;
@@ -28,9 +29,9 @@ export async function s3Update(options: S3UpdateOptions): Promise<void> {
   // However, branches are not intended for production use, so the occasional broken
   // branch does not seem worth fixing.
 
-  const { deployPath, version, branch, bucket, prefix, topBranchesJSON, localFolder} = options;
+  const { deployPath, version, branch, bucket, prefix, topBranchesJSON, localFolder, noPrefix} = options;
 
-  const topLevelS3Url = `s3://${bucket}/${prefix}`;
+  const topLevelS3Url = noPrefix ? `s3://${bucket}` : `s3://${bucket}/${prefix}`;
   const deployS3Url = `${topLevelS3Url}/${deployPath}`;
   const maxAgeSecs = version ?  MAX_AGE_VERSION_SECS : MAX_AGE_BRANCH_SECS;
 
@@ -54,7 +55,7 @@ export async function s3Update(options: S3UpdateOptions): Promise<void> {
 
       // Find all folders that contain index-top.html files and then copy their
       // remote versions to index-[branch].html
-      // This approach is used to support mono-reports that might have index-top.html files 
+      // This approach is used to support mono-reports that might have index-top.html files
       // in sub folders. The matchBase option tells glob to look for the file in all directories.
       const files = glob.sync("index-top.html", {matchBase:true, cwd: localFolder});
 


### PR DESCRIPTION
The building-models repo deploys to a top-level bucket and does not have a prefix.