### PR TITLE
feat: Added optional maxAge option [PT-185481519]

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -70,6 +70,23 @@ test('basic s3Update with version calls correct sync and copy commands', async (
   ]);
 })
 
+test('basic s3Update with optional maxAge option calls correct sync and copy commands', async () => {
+  await s3Update({
+    deployPath: 'version/v1.2.3',
+    version: 'v1.2.3',
+    bucket: 'test-bucket',
+    prefix: 'fake-app',
+    localFolder: 'test-dist-folders/basic',
+    maxAge: 600
+  });
+
+  const execMock = (exec.exec as any).mock;
+  expect(execMock.calls).toEqual([
+    ['aws s3 sync ./test-dist-folders/basic s3://test-bucket/fake-app/version/v1.2.3 --delete --exclude "*index.html" --exclude "*index-top.html" --cache-control "max-age=600"'],
+    ['aws s3 cp ./test-dist-folders/basic s3://test-bucket/fake-app/version/v1.2.3 --recursive --exclude "*" --include "*index.html" --include "*index-top.html" --cache-control "no-cache, max-age=0"']
+  ]);
+})
+
 test('s3Update with matching top branch calls correct sync and copy commands', async () => {
   await s3Update({
     deployPath: 'branch/test-branch',

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -70,7 +70,24 @@ test('basic s3Update with version calls correct sync and copy commands', async (
   ]);
 })
 
-test('basic s3Update with optional maxAge option calls correct sync and copy commands', async () => {
+test('basic s3Update with optional maxAge option set to 0 calls correct sync and copy commands', async () => {
+  await s3Update({
+    deployPath: 'version/v1.2.3',
+    version: 'v1.2.3',
+    bucket: 'test-bucket',
+    prefix: 'fake-app',
+    localFolder: 'test-dist-folders/basic',
+    maxAge: 0
+  });
+
+  const execMock = (exec.exec as any).mock;
+  expect(execMock.calls).toEqual([
+    ['aws s3 sync ./test-dist-folders/basic s3://test-bucket/fake-app/version/v1.2.3 --delete --exclude "*index.html" --exclude "*index-top.html" --cache-control "max-age=0"'],
+    ['aws s3 cp ./test-dist-folders/basic s3://test-bucket/fake-app/version/v1.2.3 --recursive --exclude "*" --include "*index.html" --include "*index-top.html" --cache-control "no-cache, max-age=0"']
+  ]);
+})
+
+test('basic s3Update with optional maxAge option set to 600 calls correct sync and copy commands', async () => {
   await s3Update({
     deployPath: 'version/v1.2.3',
     version: 'v1.2.3',

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,11 @@ inputs:
       It is relative to the workingDirectory if that is set.
       Default is 'dist'
     required: false
+  maxAge:
+    description: If present (and it is a valid decimal value) it will be used as the
+      max-age parameter for the aws sync command when copying files.  This overrides
+      the built-in values for version and branch deploys.
+    required: false
 outputs:
   deployPath:
     description: An additional path added to the prefix.

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ async function run(): Promise<void> {
     }
     localFolderParts.push(folderToDeploy || "dist");
     const localFolder = localFolderParts.join("/");
-    const maxAge = parseInt(core.getInput("maxAge"), 10) || 0;
+
+    let maxAge: number|undefined = parseInt(core.getInput("maxAge"), 10);
+    if (isNaN(maxAge)) {
+      maxAge = undefined;
+    }
 
     if (bucket && (prefix || noPrefix)) {
       process.env.AWS_ACCESS_KEY_ID = core.getInput("awsAccessKeyId");

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,8 @@ async function run(): Promise<void> {
     }
     localFolderParts.push(folderToDeploy || "dist");
     const localFolder = localFolderParts.join("/");
+    const maxAge = parseInt(core.getInput("maxAge"), 10) || 0;
+
     if (bucket && (prefix || noPrefix)) {
       process.env.AWS_ACCESS_KEY_ID = core.getInput("awsAccessKeyId");
       process.env.AWS_SECRET_ACCESS_KEY = core.getInput("awsSecretAccessKey");
@@ -48,7 +50,9 @@ async function run(): Promise<void> {
         prefix,
         noPrefix,
         topBranchesJSON,
-        localFolder });
+        localFolder,
+        maxAge
+       });
     }
 
   } catch (error) {

--- a/src/s3-update.ts
+++ b/src/s3-update.ts
@@ -34,7 +34,7 @@ export async function s3Update(options: S3UpdateOptions): Promise<void> {
 
   const topLevelS3Url = noPrefix ? `s3://${bucket}` : `s3://${bucket}/${prefix}`;
   const deployS3Url = `${topLevelS3Url}/${deployPath}`;
-  const maxAgeSecs = maxAge || (version ?  MAX_AGE_VERSION_SECS : MAX_AGE_BRANCH_SECS);
+  const maxAgeSecs = maxAge ?? (version ?  MAX_AGE_VERSION_SECS : MAX_AGE_BRANCH_SECS);
 
   // copy everything except the index and index-top files, delete anything remote
   // that isn't present locally.

--- a/src/s3-update.ts
+++ b/src/s3-update.ts
@@ -9,7 +9,8 @@ export interface S3UpdateOptions {
   prefix: string,
   topBranchesJSON?: string,
   localFolder: string,
-  noPrefix?: boolean
+  noPrefix?: boolean,
+  maxAge?: number,
 }
 
 const MAX_AGE_VERSION_SECS = 60*60*24*365;
@@ -29,11 +30,11 @@ export async function s3Update(options: S3UpdateOptions): Promise<void> {
   // However, branches are not intended for production use, so the occasional broken
   // branch does not seem worth fixing.
 
-  const { deployPath, version, branch, bucket, prefix, topBranchesJSON, localFolder, noPrefix} = options;
+  const { deployPath, version, branch, bucket, prefix, topBranchesJSON, localFolder, noPrefix, maxAge} = options;
 
   const topLevelS3Url = noPrefix ? `s3://${bucket}` : `s3://${bucket}/${prefix}`;
   const deployS3Url = `${topLevelS3Url}/${deployPath}`;
-  const maxAgeSecs = version ?  MAX_AGE_VERSION_SECS : MAX_AGE_BRANCH_SECS;
+  const maxAgeSecs = maxAge || (version ?  MAX_AGE_VERSION_SECS : MAX_AGE_BRANCH_SECS);
 
   // copy everything except the index and index-top files, delete anything remote
   // that isn't present locally.


### PR DESCRIPTION
This will allow repos like sage-modeler-site and building-models to deploy versions with custom ages.  These repos release to production by recursively copying a version folder to the top level folder.