### PR TITLE
chore: make `prefix` input optional (START-1)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   prefix:
     description: S3 prefix to prepend to files uploaded to S3
-    required: true
+    required: false
   noPrefix:
     description: If "true" the prefix is not used for the top level bucket
     required: false


### PR DESCRIPTION
[START-1](https://concord-consortium.atlassian.net/browse/START-1)

Makes `prefix` optional per [this conversation](https://github.com/concord-consortium/portal-report/pull/496#discussion_r2067781943).

[START-1]: https://concord-consortium.atlassian.net/browse/START-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ